### PR TITLE
Fix Makefile so doesn't fail with ../bin directory not found

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -8,7 +8,7 @@ LFLAGS=
 
 # create executable
 access: GlobalData.o EnvironData.o PhysChemData.o Output.o Utils.o Initialize.o Emissions.o CanopyPhysics.o DryDep.o GasChem.o Chem.o DVODE_f90_m.o Integrate.o VertTransport.o Main.o 
-	 $(FC) -o ../bin/access $(LFLAGS) GlobalData.o EnvironData.o PhysChemData.o Output.o Utils.o Initialize.o Emissions.o CanopyPhysics.o DryDep.o GasChem.o Chem.o DVODE_f90_m.o Integrate.o VertTransport.o Main.o
+	 $(FC) -o ../access $(LFLAGS) GlobalData.o EnvironData.o PhysChemData.o Output.o Utils.o Initialize.o Emissions.o CanopyPhysics.o DryDep.o GasChem.o Chem.o DVODE_f90_m.o Integrate.o VertTransport.o Main.o
 
 # compilation dependencies
 
@@ -61,4 +61,4 @@ clean:
 	rm -f -r *.o *.mod 
 
 veryclean:
-	rm -f -r *.o *.mod ../bin/access 
+	rm -f -r *.o *.mod ../access 


### PR DESCRIPTION
Found an error in the Makefile.  It seems you were installing the access binary into ../bin which didn't exist.  

Just edited it so it goes into the base directory where you had accessx 

